### PR TITLE
Use openpyxl fast path for workbook preload

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -16,6 +16,19 @@ def create_app() -> Flask:
     # API
     app.register_blueprint(api_bp)
 
+    # Prime the external workbook cache as soon as the server is ready to serve
+    # requests. Failures are logged but do not prevent the app from starting;
+    # the frontend will surface any fatal configuration issues during its
+    # bootstrap call.
+    from .routes.pricing import preload_cost_cache
+
+    @app.before_serving
+    def _warm_cache_on_startup() -> None:  # pragma: no cover - startup hook
+        try:
+            preload_cost_cache()
+        except Exception as exc:
+            app.logger.warning("Workbook cache preload skipped: %s", exc)
+
     # Index route
     @app.get("/")
     def index():

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -10,5 +10,6 @@ from . import pricing      # noqa: F401
 from . import generate     # noqa: F401
 from . import outputs      # noqa: F401
 from . import browse       # noqa: F401
+from . import bootstrap    # noqa: F401
 
 __all__ = ["api_bp"]

--- a/backend/app/routes/bootstrap.py
+++ b/backend/app/routes/bootstrap.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from flask import jsonify, current_app
+
+from .blueprint import api_bp
+from .pricing import preload_cost_cache
+
+
+@api_bp.post("/bootstrap")
+def bootstrap():
+    """Load the external workbook cache before the UI is presented."""
+
+    try:
+        result = preload_cost_cache()
+        payload = {
+            "ok": True,
+            "excel_enabled": result.get("excel_enabled", False),
+            "cache_loaded": result.get("cache_loaded", False),
+            "workbook": result.get("workbook", ""),
+            "cache_ts": result.get("cache_ts"),
+            "cache_method": result.get("cache_method"),
+        }
+        return jsonify(payload)
+    except FileNotFoundError as exc:
+        return jsonify({
+            "ok": False,
+            "errors": {"pricing": str(exc)},
+        }), 400
+    except RuntimeError as exc:
+        return jsonify({
+            "ok": False,
+            "errors": {"pricing": str(exc)},
+        }), 400
+    except Exception as exc:  # pragma: no cover - defensive logging
+        current_app.logger.exception("Bootstrap failed")
+        return jsonify({
+            "ok": False,
+            "errors": {"pricing": f"{type(exc).__name__}: {exc}"},
+        }), 500

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/style.css">
   <style>
     body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;margin:0;background:#0b0e14;color:#eaeef2}
+    body.booting header,body.booting .container{opacity:0;pointer-events:none}
+    body.ready header,body.ready .container{opacity:1;transition:opacity .3s ease}
     header{display:flex;align-items:center;gap:.75rem;padding:12px 16px;background:#101522;border-bottom:1px solid #1e2638}
     header h1{font-size:1.05rem;margin:0;color:#c7d2fe}
     nav{margin-left:auto;display:flex;gap:.5rem}
@@ -23,9 +25,19 @@
     .ok{color:#22c55e}.warn{color:#f59e0b}.err{color:#ef4444}
     a.btn{display:inline-block;padding:8px 12px;border:1px solid #2a3550;border-radius:8px;text-decoration:none;color:#cbd5e1;background:#1b2233}
     .mono{font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace}
+    #splash{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:1.25rem;background:#0b0e14;z-index:10;transition:opacity .3s ease}
+    body.ready #splash{opacity:0;pointer-events:none}
+    .spinner{width:52px;height:52px;border-radius:50%;border:4px solid rgba(59,130,246,.25);border-top-color:#3b82f6;animation:spin 1s linear infinite}
+    .splash-status{color:#cbd5e1;max-width:320px;text-align:center;line-height:1.5}
+    #splash.error .splash-status{color:#fca5a5}
+    @keyframes spin{from{transform:rotate(0)}to{transform:rotate(360deg)}}
   </style>
 </head>
-<body>
+<body class="booting">
+  <div id="splash">
+    <div class="spinner" aria-hidden="true"></div>
+    <div class="splash-status" id="splash-status">Loading external workbook…</div>
+  </div>
   <header>
     <h1>RDS Generator</h1>
     <nav>

--- a/frontend/js/main.mjs
+++ b/frontend/js/main.mjs
@@ -7,7 +7,61 @@ function activate(btn){
   btn.classList.add('active');
 }
 
+async function bootstrap(){
+  const splash = document.getElementById('splash');
+  const status = document.getElementById('splash-status');
+  const setStatus = (msg) => {
+    if(status) status.textContent = msg;
+  };
+
+  try{
+    setStatus('Loading external workbook…');
+    const resp = await fetch('/api/bootstrap', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      },
+      body: '{}'
+    });
+
+    let payload = null;
+    try{
+      payload = await resp.json();
+    }catch(e){
+      payload = null;
+    }
+
+    if(!resp.ok || !payload || payload.ok === false){
+      const message = payload?.errors?.pricing || `Bootstrap failed (${resp.status})`;
+      throw new Error(message);
+    }
+
+    if(payload.cache_loaded){
+      const method = payload.cache_method === 'openpyxl'
+        ? 'fast reader'
+        : payload.cache_method === 'com'
+          ? 'Excel automation'
+          : 'external workbook';
+      setStatus(`External workbook ready (${method}).`);
+    }else if(!payload.excel_enabled){
+      setStatus('Excel compatibility mode is off.');
+    }else{
+      setStatus('External workbook caching skipped.');
+    }
+  }catch(err){
+    console.error('Bootstrap error', err);
+    if(splash) splash.classList.add('error');
+    setStatus(err?.message || 'Failed to load external workbook.');
+  }finally{
+    document.body.classList.remove('booting');
+    await new Promise(r=>setTimeout(r, 350));
+    document.body.classList.add('ready');
+  }
+}
+
 async function mount(){
+  await bootstrap();
   const root = document.getElementById('root');
   document.getElementById('nav-settings').addEventListener('click', async (e)=>{
     activate(e.target); await renderSettings(root);


### PR DESCRIPTION
## Summary
- add an openpyxl-based fast path for priming the workbook cache before falling back to Excel COM automation
- record the loader method in the cache metadata and expose it via the bootstrap API payload
- surface the cache method in the splash screen status text so users see whether the fast reader was used

## Testing
- pytest *(fails: In test_browse_success: function uses no fixture '_patch_executor')*

------
https://chatgpt.com/codex/tasks/task_e_68d17f413e3c8324a7bd94cec17423ab