### PR TITLE
Align price list mappings with Excel labels

### DIFF
--- a/backend/app/domain/rules.py
+++ b/backend/app/domain/rules.py
@@ -1,73 +1,103 @@
 from __future__ import annotations
 from typing import Dict
+
 from .models import Inputs, Computation
+
+# ---------------------------------------------------------------------------
+# Canonical option labels (match Excel Summary sheet row labels)
+# ---------------------------------------------------------------------------
+SPARE_PARTS = "Spare Parts Package"
+SPARE_BLADES = "Spare Saw Blades"
+SPARE_PADS = "Spare Foam Pads"
+GUARD_TALLER = "Guarding – Taller"
+GUARD_NETTING = "Guarding – Netting"
+INFEED_FRONT = "Infeed – Front USL"
+INFEED_SIDE_USL = "Infeed – Side USL"
+INFEED_SIDE_BADGER = "Infeed – Side Badger"
+TRAINING_BILINGUAL = "Training (English & Spanish)"
+TRANSFORMER_CANADA = "Transformer – Canada"
+TRANSFORMER_STEP_UP = "Transformer – Step Up"
+
 
 def validate(inp: Inputs) -> Dict[str, str]:
     errors: Dict[str, str] = {}
-    for k in ['spare_blades_qty', 'spare_pads_qty']:
+    for k in ["spare_blades_qty", "spare_pads_qty"]:
         q = getattr(inp, k)
         if q % 10 != 0:
-            errors[k] = 'Quantity must be a multiple of 10 (0,10,20,30,40,50).'
-    if inp.spare_parts_qty not in (0,1):
-        errors['spare_parts_qty'] = 'Quantity must be 0 or 1.'
+            errors[k] = "Quantity must be a multiple of 10 (0,10,20,30,40,50)."
+    if inp.spare_parts_qty not in (0, 1):
+        errors["spare_parts_qty"] = "Quantity must be 0 or 1."
     return errors
 
+
+def _add_option(
+    breakdown: Dict[str, float],
+    qtys: Dict[str, int],
+    label: str,
+    unit_price: float,
+    qty: int,
+) -> None:
+    if qty <= 0:
+        return
+    breakdown[label] = unit_price * qty
+    qtys[label] = qty
+
+
 def compute_from_price_list(inp: Inputs, base_price: float, price_list: Dict[str, float]) -> Computation:
-    breakdown: Dict[str, float] = {}
-    qtys: Dict[str, int] = {}
+    breakdown: Dict[str, float] = {"Base": float(base_price)}
+    qtys: Dict[str, int] = {"Base": 1}
 
-    breakdown['Base'] = float(base_price)
-    qtys['Base'] = 1
+    _add_option(breakdown, qtys, SPARE_PARTS, price_list.get(SPARE_PARTS, 0.0), inp.spare_parts_qty)
+    _add_option(breakdown, qtys, SPARE_BLADES, price_list.get(SPARE_BLADES, 0.0), inp.spare_blades_qty)
+    _add_option(breakdown, qtys, SPARE_PADS, price_list.get(SPARE_PADS, 0.0), inp.spare_pads_qty)
 
-    if inp.spare_parts_qty:
-        unit = price_list.get('Spare Parts Package', 0.0)
-        breakdown['Spare Parts Package'] = unit * inp.spare_parts_qty
-        qtys['Spare Parts Package'] = inp.spare_parts_qty
-    if inp.spare_blades_qty:
-        unit = price_list.get('Spare Saw Blades', 0.0)
-        breakdown['Spare Saw Blades'] = unit * inp.spare_blades_qty
-        qtys['Spare Saw Blades'] = inp.spare_blades_qty
-    if inp.spare_pads_qty:
-        unit = price_list.get('Spare Foam Pads', 0.0)
-        breakdown['Spare Foam Pads'] = unit * inp.spare_pads_qty
-        qtys['Spare Foam Pads'] = inp.spare_pads_qty
+    if inp.guarding == "Tall":
+        _add_option(breakdown, qtys, GUARD_TALLER, price_list.get(GUARD_TALLER, 0.0), 1)
+    elif inp.guarding == "Tall w/ Netting":
+        _add_option(breakdown, qtys, GUARD_NETTING, price_list.get(GUARD_NETTING, 0.0), 1)
 
-    if inp.guarding == 'Tall':
-        breakdown['Taller Guarding'] = price_list.get('Taller Guarding', 0.0)
-        qtys['Taller Guarding'] = 1
-    elif inp.guarding == 'Tall w/ Netting':
-        breakdown['Taller Guarding and Netting'] = price_list.get('Taller Guarding and Netting', 0.0)
-        qtys['Taller Guarding and Netting'] = 1
+    feeding = inp.feeding
+    if feeding in {"Front USL", "Front Badger"}:
+        _add_option(breakdown, qtys, INFEED_FRONT, price_list.get(INFEED_FRONT, 0.0), 1)
+    elif feeding == "Side USL":
+        _add_option(breakdown, qtys, INFEED_SIDE_USL, price_list.get(INFEED_SIDE_USL, 0.0), 1)
+    elif feeding == "Side Badger":
+        _add_option(breakdown, qtys, INFEED_SIDE_BADGER, price_list.get(INFEED_SIDE_BADGER, 0.0), 1)
 
-    if inp.feeding in ('Front USL','Front Badger'):
-        breakdown['Front USL'] = price_list.get('Front USL', 0.0)
-        qtys['Front USL'] = 1
-    elif inp.feeding == 'Side USL':
-        breakdown['Side USL'] = price_list.get('Side USL', 0.0)
-        qtys['Side USL'] = 1
-    elif inp.feeding == 'Side Badger':
-        breakdown['Side Badger'] = price_list.get('Side Badger', 0.0)
-        qtys['Side Badger'] = 1
+    if inp.transformer == "Canada":
+        _add_option(
+            breakdown,
+            qtys,
+            TRANSFORMER_CANADA,
+            price_list.get(TRANSFORMER_CANADA, 0.0),
+            1,
+        )
+    elif inp.transformer == "Step Up":
+        _add_option(
+            breakdown,
+            qtys,
+            TRANSFORMER_STEP_UP,
+            price_list.get(TRANSFORMER_STEP_UP, 0.0),
+            1,
+        )
 
-    if inp.transformer == 'Canada':
-        breakdown['Canada Transformer'] = price_list.get('Canada Transformer', 0.0)
-        qtys['Canada Transformer'] = 1
-    elif inp.transformer == 'Step Up':
-        breakdown['Step Up Transformer'] = price_list.get('Step Up Transformer', 0.0)
-        qtys['Step Up Transformer'] = 1
+    if inp.training == "English & Spanish":
+        _add_option(
+            breakdown,
+            qtys,
+            TRAINING_BILINGUAL,
+            price_list.get(TRAINING_BILINGUAL, 0.0),
+            1,
+        )
 
-    if inp.training == 'English & Spanish':
-        breakdown['Spanish Training'] = price_list.get('Spanish Training', 0.0)
-        qtys['Spanish Training'] = 1
-
-    options_total = sum(v for k,v in breakdown.items() if k != 'Base')
+    options_total = sum(v for k, v in breakdown.items() if k != "Base")
     total = float(base_price) + float(options_total)
 
     return Computation(
-        options_breakdown={k:v for k,v in breakdown.items() if k != 'Base'},
-        options_qty={k:v for k,v in qtys.items() if k != 'Base'},
-        options_price_total=round(options_total,2),
+        options_breakdown={k: v for k, v in breakdown.items() if k != "Base"},
+        options_qty={k: v for k, v in qtys.items() if k != "Base"},
+        options_price_total=round(options_total, 2),
         margin=inp.margin,
-        base_price=round(float(base_price),2),
-        total_price=round(float(total),2),
+        base_price=round(float(base_price), 2),
+        total_price=round(float(total), 2),
     )

--- a/backend/tests/test_domain_rules.py
+++ b/backend/tests/test_domain_rules.py
@@ -9,14 +9,14 @@ def _price_list() -> dict[str, float]:
         "Spare Parts Package": 100.0,
         "Spare Saw Blades": 5.0,
         "Spare Foam Pads": 2.5,
-        "Taller Guarding": 300.0,
-        "Taller Guarding and Netting": 450.0,
-        "Front USL": 50.0,
-        "Side USL": 60.0,
-        "Side Badger": 70.0,
-        "Canada Transformer": 80.0,
-        "Step Up Transformer": 90.0,
-        "Spanish Training": 25.0,
+        "Guarding – Taller": 300.0,
+        "Guarding – Netting": 450.0,
+        "Infeed – Front USL": 50.0,
+        "Infeed – Side USL": 60.0,
+        "Infeed – Side Badger": 70.0,
+        "Transformer – Canada": 80.0,
+        "Transformer – Step Up": 90.0,
+        "Training (English & Spanish)": 25.0,
     }
 
 
@@ -42,8 +42,8 @@ def test_compute_from_price_list_accumulates_all_options():
     assert comp.options_qty["Spare Parts Package"] == 1
     assert comp.options_breakdown["Spare Saw Blades"] == 100.0
     assert comp.options_breakdown["Spare Foam Pads"] == 25.0
-    assert comp.options_breakdown["Side Badger"] == 70.0
-    assert comp.options_breakdown["Canada Transformer"] == 80.0
+    assert comp.options_breakdown["Infeed – Side Badger"] == 70.0
+    assert comp.options_breakdown["Transformer – Canada"] == 80.0
     assert comp.total_price == 1000.0 + comp.options_price_total
 
 


### PR DESCRIPTION
## Summary
- synchronize pricing rule option labels with the Excel Summary sheet so generated breakdowns use the same terminology
- update the unit tests to expect the new Excel-aligned option names

## Testing
- pytest *(fails: existing suite expects `_patch_executor` fixture injection)*

------
https://chatgpt.com/codex/tasks/task_e_68d18c55fc70832487bc9de7ea976301