### PR TITLE
Add cost grid caching and UI rendering

### DIFF
--- a/frontend/js/state.mjs
+++ b/frontend/js/state.mjs
@@ -11,10 +11,18 @@ const state = {
     transformer: 'None',
     training: 'English'
   },
-  outputs: null
+  outputs: null,
+  costGrid: []
 };
 
 export function getState(){ return state; }
 export function setSettings(s){ state.settings = s; }
 export function setInputs(i){ state.inputs = {...state.inputs, ...i}; }
 export function setOutputs(o){ state.outputs = o; }
+export function setCostGrid(grid){
+  if (!Array.isArray(grid)) {
+    state.costGrid = [];
+    return;
+  }
+  state.costGrid = grid.map(row => Array.isArray(row) ? [...row] : []);
+}


### PR DESCRIPTION
## Summary
- cache the Summary!C4:K55 cost grid alongside the base and option costs
- extend the Excel pricing engine to normalize and expose the cost grid for COM and openpyxl loaders
- render a third card on the inputs view that shows the cached cost grid with loading and error states

## Testing
- pytest backend/tests/test_routes_pricing.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e358583108324bb3b438e2c8e9a40)